### PR TITLE
WIP: Adds 'lenderName' to existing loans

### DIFF
--- a/src/main/kotlin/org/openbroker/se/privateunsecuredloan/model/ExistingLoan.kt
+++ b/src/main/kotlin/org/openbroker/se/privateunsecuredloan/model/ExistingLoan.kt
@@ -7,7 +7,8 @@ data class ExistingLoan(
     val monthlyPayment: Int,
     val shouldRefinance: Boolean,
     val existingLoanType: ExistingLoanType,
-    val responsibility: Responsibility
+    val responsibility: Responsibility,
+    val lenderName: String? = null
 ) {
     init {
     	loanAmount.requireMin(1, "loanAmount")

--- a/src/test/kotlin/org/openbroker/se/privateunsecuredloan/TestObjectsJson.kt
+++ b/src/test/kotlin/org/openbroker/se/privateunsecuredloan/TestObjectsJson.kt
@@ -112,7 +112,7 @@ object TestObjectsJson {
 					"shouldRefinance": true,
 					"existingLoanType": "CAR_LOAN",
 					"responsibility": "SHARED",
-                    "lenderName": "banksy"
+					"lenderName": "banksy"
 				},
 				{
 					"loanAmount": 15000,
@@ -172,7 +172,7 @@ object TestObjectsJson {
 					"shouldRefinance": false,
 					"existingLoanType": "STUDENT_LOAN",
 					"responsibility": "MAIN_APPLICANT",
-                    "lenderName": "a lender"
+					"lenderName": "a lender"
 				}
 			],
 			"extensions": {

--- a/src/test/kotlin/org/openbroker/se/privateunsecuredloan/TestObjectsJson.kt
+++ b/src/test/kotlin/org/openbroker/se/privateunsecuredloan/TestObjectsJson.kt
@@ -111,7 +111,8 @@ object TestObjectsJson {
 					"monthlyPayment": 22,
 					"shouldRefinance": true,
 					"existingLoanType": "CAR_LOAN",
-					"responsibility": "SHARED"
+					"responsibility": "SHARED",
+                    "lenderName": "banksy"
 				},
 				{
 					"loanAmount": 15000,
@@ -170,7 +171,8 @@ object TestObjectsJson {
 					"monthlyPayment": 56,
 					"shouldRefinance": false,
 					"existingLoanType": "STUDENT_LOAN",
-					"responsibility": "MAIN_APPLICANT"
+					"responsibility": "MAIN_APPLICANT",
+                    "lenderName": "a lender"
 				}
 			],
 			"extensions": {


### PR DESCRIPTION
Adds attribute 'lenderName' to existing loan. 

We collect the info so it should be accessable for the integrations.

It is a required value in the database. But it is set here as a nullable value, with default value null.
The reason for this is backwards compatability. Is that a valid reason though?