### PR TITLE
Add support for Mortgage Norway

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,4 +11,3 @@ trim_trailing_whitespace=true
 [{*.yml,*.yaml}]
 indent_style=space
 indent_size=2
-

--- a/src/main/kotlin/org/openbroker/common/meta/EventType.kt
+++ b/src/main/kotlin/org/openbroker/common/meta/EventType.kt
@@ -1,6 +1,7 @@
 package org.openbroker.common.meta
 
 import org.openbroker.common.OpenBrokerEvent
+import org.openbroker.no.mortgage.MortgageNorway
 import org.openbroker.no.privateunsecuredloan.PrivateUnsecuredLoanNorway
 import org.openbroker.se.mortgage.MortgageSweden
 import org.openbroker.se.privateunsecuredloan.PrivateUnsecuredLoanSweden
@@ -20,7 +21,8 @@ interface EventType<T: OpenBrokerEvent>{
 private val knownOpenBrokerDomains: List<EventTypeFactory<*>> = listOf(
     PrivateUnsecuredLoanNorway,
     PrivateUnsecuredLoanSweden,
-    MortgageSweden
+    MortgageSweden,
+    MortgageNorway
 )
 
 fun <T: OpenBrokerEvent> eventType(clazz: Class<out T>): EventType<T> {

--- a/src/main/kotlin/org/openbroker/common/serialize/Serialization.kt
+++ b/src/main/kotlin/org/openbroker/common/serialize/Serialization.kt
@@ -8,10 +8,10 @@ import org.openbroker.common.OpenBrokerEvent
 import org.openbroker.common.meta.EventType
 import org.openbroker.common.meta.eventType
 
-private inline fun <reified T: OpenBrokerEvent> parse(json: String): T =
+inline fun <reified T: OpenBrokerEvent> parseJsonCloudEvent(json: String): CloudEvent<T> =
     jacksonObjectMapper().readValue(json)
 
-private fun <T: OpenBrokerEvent> parse(json: String, clazz: Class<T>): OpenBrokerEvent =
+fun <T: OpenBrokerEvent> parseJson(json: String, clazz: Class<T>): OpenBrokerEvent =
     jacksonObjectMapper().readValue(json, clazz)
 
 fun parseOpenBrokerEvent(payload: String): CloudEvent<OpenBrokerEvent> {
@@ -22,7 +22,7 @@ fun parseOpenBrokerEvent(payload: String): CloudEvent<OpenBrokerEvent> {
 fun CloudEvent<JsonNode>.toOpenBrokerEvent(): CloudEvent<OpenBrokerEvent> {
     val data: String = jacksonObjectMapper().writeValueAsString(this.data)
     val eventType: EventType<OpenBrokerEvent> = eventType(this.eventType)
-    val event: OpenBrokerEvent = parse(data, eventType.clazz)
+    val event: OpenBrokerEvent = parseJson(data, eventType.clazz)
     return this.withData(event)
 }
 
@@ -36,10 +36,11 @@ fun restoreOpenBrokerEvent(event: CloudEvent<*>): CloudEvent<OpenBrokerEvent>? {
         return null
     val data: String = jacksonObjectMapper().writeValueAsString(event.data)
     val type: EventType<OpenBrokerEvent> = eventType(event.eventType)
-    val openBrokerEvent: OpenBrokerEvent = parse(data, type.clazz)
+    val openBrokerEvent: OpenBrokerEvent = parseJson(data, type.clazz)
     return event.withData(openBrokerEvent)
 }
 
+@Suppress("UNCHECKED_CAST")
 fun <T: OpenBrokerEvent> CloudEvent<*>.withData(data: T): CloudEvent<OpenBrokerEvent> {
     if(this.data == data)
         return this as CloudEvent<OpenBrokerEvent>

--- a/src/main/kotlin/org/openbroker/no/mortgage/MortgageNorway.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/MortgageNorway.kt
@@ -1,4 +1,37 @@
 package org.openbroker.no.mortgage
 
-enum class MortgageNorway {
+import org.openbroker.common.meta.EventType
+import org.openbroker.common.meta.EventTypeFactory
+import org.openbroker.common.meta.EventTypeQualifier
+import org.openbroker.common.meta.QualifiedName
+import org.openbroker.no.mortgage.events.ApplicationCreated
+import org.openbroker.no.mortgage.events.MortgageEvent
+import org.openbroker.no.mortgage.events.Offering
+import org.openbroker.no.mortgage.events.ApplicationRejection
+import org.openbroker.no.mortgage.events.Disbursed
+import org.openbroker.no.mortgage.events.Message
+import org.openbroker.no.mortgage.events.OfferAccepted
+import org.openbroker.no.mortgage.events.OfferRejected
+
+enum class MortgageNorway(
+    override val clazz: Class<out MortgageEvent>
+): EventType<MortgageEvent> {
+    APPLICATION_CREATED(ApplicationCreated::class.java),
+    OFFERING(Offering::class.java),
+    APPLICATION_REJECTION(ApplicationRejection::class.java),
+    OFFER_REJECTED(OfferRejected::class.java),
+    OFFER_ACCEPTED(OfferAccepted::class.java),
+    DISBURSED(Disbursed::class.java),
+    MESSAGE(Message::class.java);
+
+    override fun eventName(): QualifiedName = MortgageNorway.qualifier.withClass(clazz)
+
+    companion object: EventTypeFactory<MortgageEvent> {
+        override fun values(): Array<out EventType<MortgageEvent>> = MortgageNorway.values()
+        override val qualifier: EventTypeQualifier = EventTypeQualifier(
+            version = "v0",
+            region = "no",
+            domain = "Mortgage"
+        )
+    }
 }

--- a/src/main/kotlin/org/openbroker/no/mortgage/MortgageNorway.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/MortgageNorway.kt
@@ -1,0 +1,4 @@
+package org.openbroker.no.mortgage
+
+enum class MortgageNorway {
+}

--- a/src/main/kotlin/org/openbroker/no/mortgage/events/ApplicationCreated.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/events/ApplicationCreated.kt
@@ -1,0 +1,17 @@
+package org.openbroker.no.mortgage.events
+
+import org.openbroker.common.model.DataProtectionContext
+import org.openbroker.common.model.InformationContext
+import org.openbroker.common.model.Reference
+import org.openbroker.no.mortgage.model.Application
+
+
+/**
+ * An event indicating the creation of an application
+ * for a private unsecured loan
+ */
+data class ApplicationCreated(
+    val application: Application,
+    override val brokerReference: Reference,
+    override val dataProtectionContext: DataProtectionContext
+): MortgageEvent, InformationContext

--- a/src/main/kotlin/org/openbroker/no/mortgage/events/ApplicationRejection.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/events/ApplicationRejection.kt
@@ -5,4 +5,7 @@ import org.openbroker.common.model.Reference
 /**
  *  An event indicating that the application was rejected
  */
-data class ApplicationRejection(override val brokerReference: Reference): MortgageEvent
+data class ApplicationRejection(
+    override val brokerReference: Reference,
+    val rejectReason: String? = null
+): MortgageEvent

--- a/src/main/kotlin/org/openbroker/no/mortgage/events/ApplicationRejection.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/events/ApplicationRejection.kt
@@ -1,0 +1,8 @@
+package org.openbroker.no.mortgage.events
+
+import org.openbroker.common.model.Reference
+
+/**
+ *  An event indicating that the application was rejected
+ */
+data class ApplicationRejection(override val brokerReference: Reference): MortgageEvent

--- a/src/main/kotlin/org/openbroker/no/mortgage/events/Disbursed.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/events/Disbursed.kt
@@ -1,0 +1,41 @@
+package org.openbroker.no.mortgage.events
+
+import org.openbroker.common.model.Reference
+import org.openbroker.common.requireMin
+
+/**
+ * An event indicating that a private unsecured loan has been disbursed
+ */
+data class Disbursed(
+    override val brokerReference: Reference,
+
+    /**
+     * The total amount disbursed to the customer of the loan being brokered
+     */
+    val amountDisbursed: Int,
+
+    /**
+     * The amount the lender considers the broker to have
+     * brokered. For example, the amount disbursed exclusive
+     * of loans refinanced within the lender.
+     */
+    val amountBrokered: Int,
+    /**
+     *  The date for which the loan was disbursed, formatted
+     *  as a ISO-8601 date, in the extended format YYYY-MM-DD
+     */
+    val date: String
+): MortgageEvent {
+    init {
+        amountDisbursed.requireMin(1, "amountDisbursed")
+        amountBrokered.requireMin(0, "amountBrokered")
+
+        require(amountBrokered <= amountDisbursed) {
+            "amountBrokered ($amountBrokered) must be equal to or less than amountDisbursed ($amountDisbursed)"
+        }
+
+        require(date.matches(Regex("\\d{4}-\\d{2}-\\d{2}"))) {
+            "Invalid date argument: '$date'"
+        }
+    }
+}

--- a/src/main/kotlin/org/openbroker/no/mortgage/events/Message.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/events/Message.kt
@@ -1,0 +1,13 @@
+package org.openbroker.no.mortgage.events
+
+import org.openbroker.common.model.Reference
+
+/**
+ * An event containing information on the loan process
+ */
+
+data class Message constructor(
+    override val brokerReference: Reference,
+    val message: String,
+    val requiresAction: Boolean
+) : MortgageEvent

--- a/src/main/kotlin/org/openbroker/no/mortgage/events/MortgageEvent.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/events/MortgageEvent.kt
@@ -1,0 +1,8 @@
+package org.openbroker.no.mortgage.events
+
+import org.openbroker.common.OpenBrokerEvent
+
+/**
+ * An interface for all Private Unsecured Loan events
+ */
+interface MortgageEvent: OpenBrokerEvent

--- a/src/main/kotlin/org/openbroker/no/mortgage/events/OfferAccepted.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/events/OfferAccepted.kt
@@ -2,7 +2,6 @@ package org.openbroker.no.mortgage.events
 
 import org.openbroker.common.model.Reference
 import org.openbroker.common.requireMin
-import org.openbroker.se.mortgage.events.MortgageEvent
 
 data class OfferAccepted @JvmOverloads constructor(
     override val brokerReference: Reference,

--- a/src/main/kotlin/org/openbroker/no/mortgage/events/OfferAccepted.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/events/OfferAccepted.kt
@@ -1,0 +1,16 @@
+package org.openbroker.no.mortgage.events
+
+import org.openbroker.common.model.Reference
+import org.openbroker.common.requireMin
+import org.openbroker.se.mortgage.events.MortgageEvent
+
+data class OfferAccepted @JvmOverloads constructor(
+    override val brokerReference: Reference,
+    val bankAccount: String? = null,
+    val requestedCredit: Int? = null
+): MortgageEvent
+{
+    init {
+        requestedCredit.requireMin(1, "requestedCredit")
+    }
+}

--- a/src/main/kotlin/org/openbroker/no/mortgage/events/OfferRejected.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/events/OfferRejected.kt
@@ -1,0 +1,9 @@
+package org.openbroker.no.privateunsecuredloan.events
+
+import org.openbroker.common.model.Reference
+
+/**
+ * An event that may be sent by the broker to indicate that
+ * the offer has been rejected
+ */
+data class OfferRejected(override val brokerReference: Reference): PrivateUnsecuredLoanEvent

--- a/src/main/kotlin/org/openbroker/no/mortgage/events/OfferRejected.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/events/OfferRejected.kt
@@ -1,4 +1,4 @@
-package org.openbroker.no.privateunsecuredloan.events
+package org.openbroker.no.mortgage.events
 
 import org.openbroker.common.model.Reference
 
@@ -6,4 +6,4 @@ import org.openbroker.common.model.Reference
  * An event that may be sent by the broker to indicate that
  * the offer has been rejected
  */
-data class OfferRejected(override val brokerReference: Reference): PrivateUnsecuredLoanEvent
+data class OfferRejected(override val brokerReference: Reference): MortgageEvent

--- a/src/main/kotlin/org/openbroker/no/mortgage/events/Offering.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/events/Offering.kt
@@ -1,0 +1,14 @@
+package org.openbroker.no.privateunsecuredloan.events
+
+import org.openbroker.common.model.Reference
+import org.openbroker.no.privateunsecuredloan.model.LoanInsuranceOffer
+import org.openbroker.no.privateunsecuredloan.model.Offer
+
+/**
+ * An offer for a loan
+ */
+data class Offering @JvmOverloads constructor(
+    override val brokerReference: Reference,
+    val offer: Offer,
+    val loanInsuranceOffer: LoanInsuranceOffer? = null
+): PrivateUnsecuredLoanEvent

--- a/src/main/kotlin/org/openbroker/no/mortgage/events/Offering.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/events/Offering.kt
@@ -1,4 +1,4 @@
-package org.openbroker.no.privateunsecuredloan.events
+package org.openbroker.no.mortgage.events
 
 import org.openbroker.common.model.Reference
 import org.openbroker.no.privateunsecuredloan.model.LoanInsuranceOffer
@@ -11,4 +11,4 @@ data class Offering @JvmOverloads constructor(
     override val brokerReference: Reference,
     val offer: Offer,
     val loanInsuranceOffer: LoanInsuranceOffer? = null
-): PrivateUnsecuredLoanEvent
+): MortgageEvent

--- a/src/main/kotlin/org/openbroker/no/mortgage/events/Offering.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/events/Offering.kt
@@ -1,14 +1,12 @@
 package org.openbroker.no.mortgage.events
 
 import org.openbroker.common.model.Reference
-import org.openbroker.no.privateunsecuredloan.model.LoanInsuranceOffer
-import org.openbroker.no.privateunsecuredloan.model.Offer
+import org.openbroker.no.mortgage.model.Offer
 
 /**
  * An offer for a loan
  */
-data class Offering @JvmOverloads constructor(
+data class Offering constructor(
     override val brokerReference: Reference,
-    val offer: Offer,
-    val loanInsuranceOffer: LoanInsuranceOffer? = null
+    val offer: Offer
 ): MortgageEvent

--- a/src/main/kotlin/org/openbroker/no/mortgage/events/Rejection.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/events/Rejection.kt
@@ -1,8 +1,0 @@
-package org.openbroker.no.privateunsecuredloan.events
-
-import org.openbroker.common.model.Reference
-
-/**
- *  An event indicating that the application was rejected
- */
-data class Rejection(override val brokerReference: Reference): PrivateUnsecuredLoanEvent

--- a/src/main/kotlin/org/openbroker/no/mortgage/events/Rejection.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/events/Rejection.kt
@@ -1,0 +1,8 @@
+package org.openbroker.no.privateunsecuredloan.events
+
+import org.openbroker.common.model.Reference
+
+/**
+ *  An event indicating that the application was rejected
+ */
+data class Rejection(override val brokerReference: Reference): PrivateUnsecuredLoanEvent

--- a/src/main/kotlin/org/openbroker/no/mortgage/model/AmortizationType.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/model/AmortizationType.kt
@@ -1,0 +1,20 @@
+package org.openbroker.no.mortgage.model
+
+/**
+ * Decides in which manner the loan is amortized
+ */
+enum class AmortizationType {
+    /**
+     * The monthly sum that is payed by the customer is fixed, and the amount
+     * that is amortized is gradually increased since the the amount to cover
+     * the interest rate each month decreases which each amortisation
+     */
+    ANNUITY,
+
+    /**
+     * The amount paid for amortization each month is fixed, while the interest
+     * payment will be lower over time, meaning that the total monthly cost for
+     * the loan will decrease over time
+     */
+    STRAIGHT_LINE
+}

--- a/src/main/kotlin/org/openbroker/no/mortgage/model/Applicant.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/model/Applicant.kt
@@ -1,0 +1,70 @@
+package org.openbroker.no.mortgage.model
+
+import org.openbroker.common.obfuscateDigits
+import org.openbroker.common.requireMin
+import org.openbroker.no.model.Address
+import org.openbroker.no.model.EmploymentStatus
+import org.openbroker.no.model.HousingType
+import org.openbroker.no.model.MaritalStatus
+
+data class Applicant @JvmOverloads constructor(
+    val ssn: String,
+    val phone: String? = null,
+    val secondaryPhone: List<String> = emptyList(),
+    val emailAddress: String? = null,
+    val employmentStatus: EmploymentStatus,
+    val employmentStatusSinceYear: Int,
+    val employmentStatusSinceMonth: Int,
+    val employerName: String? = null,
+    val employerPhone: String? = null,
+    val dependentChildren: Int,
+    val childSupportReceivedMonthly: Int? = null,
+    val rentReceivedMonthly: Int? = null,
+    val otherIncomeReceivedMonthly: Int? = null,
+    val childSupportPaidMonthly: Int? = null,
+    val paymentRemark: Boolean,
+    val housingType: HousingType,
+    val housingSinceYear: Int,
+    val housingSinceMonth: Int,
+    val housingCostPerMonth: Int,
+    val monthlyGrossIncome: Int,
+    val monthlyNetIncome: Int,
+    val maritalStatus: MaritalStatus,
+    val norwegianCitizen: Boolean,
+    val education: Education,
+    val tentativeAddress: Address? = null
+    ) {
+
+    init {
+        val ssnRegex = Regex("^[0-9]{11}$")
+        require(ssn.matches(ssnRegex)) { "Invalid SSN: '${obfuscateDigits(ssn)}'" }
+
+        val phoneRegex = Regex("^\\+[1-9][0-9]{1,14}\$")
+        phone?.let {
+            require(it.matches(phoneRegex)) {
+                "Invalid primary phone number: '$it'"
+            }
+        }
+        require(secondaryPhone.all { it.matches(phoneRegex) }) {
+            "Invalid secondary phone number in $secondaryPhone"
+        }
+        employerPhone?.let {
+            require(it.matches(phoneRegex)) {
+                "Invalid employer phone number: '$it'"
+            }
+        }
+        require(employmentStatusSinceYear in 1900..3000)
+        require(employmentStatusSinceMonth in 1..12)
+        require(housingSinceYear in 1900..3000)
+        require(housingSinceMonth in 1..12)
+        require(dependentChildren in 0..15)
+        childSupportReceivedMonthly.requireMin(0, "childSupportReceivedMonthly")
+        rentReceivedMonthly.requireMin(0, "rentReceivedMonthly")
+        otherIncomeReceivedMonthly.requireMin(0, "otherIncomeReceivedMonthly")
+        childSupportPaidMonthly.requireMin(0, "childSupportPaidMonthly")
+        housingCostPerMonth.requireMin(0, "housingCostPerMonth")
+        monthlyNetIncome.requireMin(0, "monthlyNetIncome")
+        monthlyGrossIncome.requireMin(0, "monthlyGrossIncome")
+    }
+
+}

--- a/src/main/kotlin/org/openbroker/no/mortgage/model/Applicant.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/model/Applicant.kt
@@ -31,7 +31,7 @@ data class Applicant @JvmOverloads constructor(
     val norwegianCitizen: Boolean,
     val education: Education? = null,
     val tentativeAddress: Address? = null
-    ) {
+) {
 
     init {
         val ssnRegex = Regex("^[0-9]{11}$")
@@ -61,6 +61,9 @@ data class Applicant @JvmOverloads constructor(
         housingCostPerMonth.requireMin(0, "housingCostPerMonth")
         monthlyNetIncome.requireMin(0, "monthlyNetIncome")
         monthlyGrossIncome.requireMin(0, "monthlyGrossIncome")
+        require(monthlyNetIncome <= monthlyGrossIncome) {
+            "Value for monthlyNetIncome cannot be greater than value for monthlyGrossIncome"
+        }
     }
 
 }

--- a/src/main/kotlin/org/openbroker/no/mortgage/model/Applicant.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/model/Applicant.kt
@@ -29,7 +29,7 @@ data class Applicant @JvmOverloads constructor(
     val monthlyNetIncome: Int,
     val maritalStatus: MaritalStatus,
     val norwegianCitizen: Boolean,
-    val education: Education,
+    val education: Education? = null,
     val tentativeAddress: Address? = null
     ) {
 

--- a/src/main/kotlin/org/openbroker/no/mortgage/model/Applicant.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/model/Applicant.kt
@@ -24,8 +24,6 @@ data class Applicant @JvmOverloads constructor(
     val childSupportPaidMonthly: Int? = null,
     val paymentRemark: Boolean,
     val housingType: HousingType,
-    val housingSinceYear: Int,
-    val housingSinceMonth: Int,
     val housingCostPerMonth: Int,
     val monthlyGrossIncome: Int,
     val monthlyNetIncome: Int,
@@ -55,8 +53,6 @@ data class Applicant @JvmOverloads constructor(
         }
         require(employmentStatusSinceYear in 1900..3000)
         require(employmentStatusSinceMonth in 1..12)
-        require(housingSinceYear in 1900..3000)
-        require(housingSinceMonth in 1..12)
         require(dependentChildren in 0..15)
         childSupportReceivedMonthly.requireMin(0, "childSupportReceivedMonthly")
         rentReceivedMonthly.requireMin(0, "rentReceivedMonthly")

--- a/src/main/kotlin/org/openbroker/no/mortgage/model/Application.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/model/Application.kt
@@ -45,8 +45,13 @@ data class Application @JvmOverloads constructor(
     /**
      * The number of year terms that the applicant desires to pay off the loan over
      */
-    val termYears: Int
-    ) {
+    val termYears: Int,
+    /**
+     * An optional human-readable comment about the application, presenting
+     * extra information about the application, such as cause to today's situation.
+     */
+    val comment: String? = null
+) {
     init {
         loanAmount.requireMin(1, "loanAmount")
         refinanceAmount.requireMin(0, "refinanceAmount")

--- a/src/main/kotlin/org/openbroker/no/mortgage/model/Application.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/model/Application.kt
@@ -1,0 +1,63 @@
+package org.openbroker.no.mortgage.model
+
+import org.openbroker.common.model.issuerRegex
+import org.openbroker.common.requireMin
+
+data class Application @JvmOverloads constructor(
+    /**
+     * The primary applicant to the loan
+     */
+    val applicant: Applicant,
+
+    /**
+     * A secondary applicant for the loan, if any
+     */
+    val coApplicant: Applicant? = null,
+
+    /**
+     * Information about existing loans relevant to the applicant
+     */
+    val existingLoans: List<ExistingLoan> = emptyList(),
+
+
+    val refinancingProperty: RefinancingProperty,
+
+    /**
+     * Custom, vendor-specific extensions to the schema
+     */
+    val extensions: Map<String, Any>? = emptyMap(),
+
+    /**
+     * The amount that the customer wishes to borrow
+     */
+    val loanAmount: Int,
+
+    /**
+     * Purpose of the loan
+     */
+    val loanPurpose: LoanPurpose = LoanPurpose.OTHER,
+
+    /**
+     * The amount being refinanced, must be less than the loanAmount
+     */
+    val refinanceAmount: Int = 0,
+
+    /**
+     * The number 1-month terms that the applicant desires to pay off the loan over
+     */
+    val termMonths: Int
+    ) {
+    init {
+        loanAmount.requireMin(1, "loanAmount")
+        refinanceAmount.requireMin(0, "refinanceAmount")
+        termMonths.requireMin(1, "termMonths")
+        require(refinanceAmount <= loanAmount) {
+            "refinanceAmount ($refinanceAmount) may not be greater than loanAmount ($loanAmount)."
+        }
+        extensions?.keys?.forEach { key ->
+            require(key.matches(issuerRegex)) {
+                "Key for extension is not a valid format: '$key'"
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/openbroker/no/mortgage/model/Application.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/model/Application.kt
@@ -43,14 +43,14 @@ data class Application @JvmOverloads constructor(
     val refinanceAmount: Int = 0,
 
     /**
-     * The number 1-month terms that the applicant desires to pay off the loan over
+     * The number of year terms that the applicant desires to pay off the loan over
      */
-    val termMonths: Int
+    val termYears: Int
     ) {
     init {
         loanAmount.requireMin(1, "loanAmount")
         refinanceAmount.requireMin(0, "refinanceAmount")
-        termMonths.requireMin(1, "termMonths")
+        termYears.requireMin(1, "termYears")
         require(refinanceAmount <= loanAmount) {
             "refinanceAmount ($refinanceAmount) may not be greater than loanAmount ($loanAmount)."
         }

--- a/src/main/kotlin/org/openbroker/no/mortgage/model/Education.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/model/Education.kt
@@ -1,0 +1,20 @@
+package org.openbroker.no.mortgage.model
+
+enum class Education {
+    /**
+     * Completed the obligatory first stage of formal education
+     */
+    PRIMARY_SCHOOL,
+    /**
+     * Completed the formal education preparing for higher studies
+     */
+    SECONDARY_SCHOOL,
+    /**
+     * Completed 1-3 years of higher education
+     */
+    UNIVERSITY_SHORT,
+    /**
+     * Completed 4 or more years of higher education
+     */
+    UNIVERSITY_LONG
+}

--- a/src/main/kotlin/org/openbroker/no/mortgage/model/ExistingLoan.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/model/ExistingLoan.kt
@@ -1,0 +1,19 @@
+package org.openbroker.no.mortgage.model
+
+import org.openbroker.common.requireMin
+
+data class ExistingLoan(
+    val loanAmount: Int,
+    val monthlyPayment: Int,
+    val refinanceAmount: Int? = null,
+    val existingLoanType: ExistingLoanType,
+    val responsibility: Responsibility,
+    val lender: String,
+    val defaulted: Boolean
+) {
+    init {
+        loanAmount.requireMin(1, "loanAmount")
+        monthlyPayment.requireMin(1, "monthlyPayment")
+        require(lender.isNotEmpty())
+    }
+}

--- a/src/main/kotlin/org/openbroker/no/mortgage/model/ExistingLoanType.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/model/ExistingLoanType.kt
@@ -1,0 +1,28 @@
+package org.openbroker.no.mortgage.model
+
+enum class ExistingLoanType {
+    /**
+     * A loan for a car or similar vehicle
+     */
+    CAR_LOAN,
+    /**
+     * A credit-card
+     */
+    CREDIT_CARD,
+    /**
+     * A home mortgage
+     */
+    MORTGAGE,
+    /**
+     * A student loan
+     */
+    STUDENT_LOAN,
+    /**
+     * An unsecured loan, not falling into any of the other categories, for example a consumer loan
+     */
+    UNSECURED_LOAN,
+    /**
+     * Any other debt not falling into any of the other categories
+     */
+    OTHER
+}

--- a/src/main/kotlin/org/openbroker/no/mortgage/model/LoanPurpose.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/model/LoanPurpose.kt
@@ -1,0 +1,20 @@
+package org.openbroker.no.mortgage.model
+
+enum class LoanPurpose {
+    /**
+     * Refinancing of private unsecured loans with the existing mortgage
+     */
+    REFINANCE_CONSUMER_LOANS,
+    /**
+     * Refinancing of an existing mortgage
+     */
+    REFINANCE_MORTGAGE,
+    /**
+     * Home remodelling or renovation
+     */
+    HOME_REMODELLING,
+    /**
+     * Purpose not fitting the above categories
+     */
+    OTHER
+}

--- a/src/main/kotlin/org/openbroker/no/mortgage/model/Offer.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/model/Offer.kt
@@ -1,0 +1,35 @@
+package org.openbroker.no.mortgage.model
+
+import org.openbroker.common.requireMin
+
+data class Offer(
+    val effectiveInterestRate: String,
+    val nominalInterestRate: String,
+    val offeredCredit: Int,
+    val monthlyCost: Int? = null,
+    val mustRefinance: Int,
+    val arrangementFee: Int,
+    val termFee: Int,
+    val invoiceFee: Int,
+    val termMonths: Int,
+    val amortizationType: AmortizationType
+) {
+    init {
+        val interestRateRegex = Regex("^[0-9]+(.[0-9]+)?$")
+
+        require(effectiveInterestRate.matches(interestRateRegex)) {
+            "Bad format of effective interest rate: '$effectiveInterestRate'"
+        }
+
+        require(nominalInterestRate.matches(interestRateRegex)) {
+            "Bad format of nominal interest rate: '$nominalInterestRate'"
+        }
+
+        offeredCredit.requireMin(1, "offeredCredit")
+        mustRefinance.requireMin(0, "mustRefinance")
+        arrangementFee.requireMin(0, "arrangementFee")
+        termFee.requireMin(0, "termFee")
+        invoiceFee.requireMin(0, "invoiceFee")
+        termMonths.requireMin(1, "termMonths")
+    }
+}

--- a/src/main/kotlin/org/openbroker/no/mortgage/model/Offer.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/model/Offer.kt
@@ -11,7 +11,7 @@ data class Offer(
     val arrangementFee: Int,
     val termFee: Int,
     val invoiceFee: Int,
-    val termMonths: Int,
+    val termYears: Int,
     val amortizationType: AmortizationType
 ) {
     init {
@@ -30,6 +30,6 @@ data class Offer(
         arrangementFee.requireMin(0, "arrangementFee")
         termFee.requireMin(0, "termFee")
         invoiceFee.requireMin(0, "invoiceFee")
-        termMonths.requireMin(1, "termMonths")
+        termYears.requireMin(1, "termYears")
     }
 }

--- a/src/main/kotlin/org/openbroker/no/mortgage/model/PropertyAddress.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/model/PropertyAddress.kt
@@ -1,0 +1,17 @@
+package org.openbroker.no.mortgage.model
+
+data class PropertyAddress(
+    val streetAddress: String,
+    val city: String,
+    val postalCode: String
+) {
+    init {
+        require(streetAddress.isNotBlank())
+        require(city.isNotBlank())
+        require(postalCode.matches(postalCodeRegex))
+    }
+
+    companion object {
+        val postalCodeRegex = Regex("^\\d{4}$")
+    }
+}

--- a/src/main/kotlin/org/openbroker/no/mortgage/model/PropertyType.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/model/PropertyType.kt
@@ -1,0 +1,31 @@
+package org.openbroker.no.mortgage.model
+
+enum class PropertyType {
+    /**
+     * An ordinary house with a plot
+     */
+    HOUSE,
+    /**
+     * A house that is built adjacent to other houses
+     */
+    TERRACED_HOUSE,
+    /**
+     *  A house built for recreational living that may or may not
+     *  be fit as a permanent resident
+     */
+    VACATION_HOME,
+    /**
+     *  An apartment that is owned directly by the applicant and does not
+     *  belong to a condominium compound
+     */
+    APARTMENT_SELF_OWNED,
+    /**
+     * An apartment that belongs to condominium compound
+     */
+    APARTMENT_COOPERATIVE,
+    /**
+     * Some other form of real-estate property that does not belong
+     * to any of the above categories
+     */
+    OTHER
+}

--- a/src/main/kotlin/org/openbroker/no/mortgage/model/RefinancingProperty.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/model/RefinancingProperty.kt
@@ -10,6 +10,7 @@ data class RefinancingProperty(
     val squareMeters: Int,
     val existingMortgage: Int,
     val monthlyCost: Int,
+    val condominiumCompoundDebt: Int? = null,
     val defaulted: Boolean
 ) {
     init {
@@ -17,6 +18,7 @@ data class RefinancingProperty(
         squareMeters.requireMin(0, "squareMeters")
         existingMortgage.requireMin(0, "existingMortgage")
         monthlyCost.requireMin(0, "monthlyCost")
+        condominiumCompoundDebt.requireMin(0, "condominiumCompoundDebt")
         require(interestRate.matches(interestRateRegex)) {
             "Value interestRate has invalid format: '$interestRate'"
         }

--- a/src/main/kotlin/org/openbroker/no/mortgage/model/RefinancingProperty.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/model/RefinancingProperty.kt
@@ -1,0 +1,28 @@
+package org.openbroker.no.mortgage.model
+
+import org.openbroker.common.requireMin
+
+data class RefinancingProperty(
+    val propertyAddress: PropertyAddress,
+    val propertyType: PropertyType,
+    val interestRate: String,
+    val assessedValue: Int,
+    val squareMeters: Int,
+    val existingMortgage: Int,
+    val monthlyCost: Int,
+    val defaulted: Boolean
+) {
+    init {
+        assessedValue.requireMin(0, "assessedValue")
+        squareMeters.requireMin(0, "squareMeters")
+        existingMortgage.requireMin(0, "existingMortgage")
+        monthlyCost.requireMin(0, "monthlyCost")
+        require(interestRate.matches(interestRateRegex)) {
+            "Value interestRate has invalid format: '$interestRate'"
+        }
+    }
+
+    companion object {
+        private val interestRateRegex = Regex("^\\d\\.\\d+\$")
+    }
+}

--- a/src/main/kotlin/org/openbroker/no/mortgage/model/Responsibility.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/model/Responsibility.kt
@@ -1,0 +1,18 @@
+package org.openbroker.no.mortgage.model
+
+enum class Responsibility {
+    /**
+     * The main applicant is responsible for this loan
+     */
+    MAIN_APPLICANT,
+
+    /**
+     * The co-applicant is responsible for this loan
+     */
+    CO_APPLICANT,
+
+    /**
+     * The loan is a shared responsibility for the applicants
+     */
+    SHARED
+}

--- a/src/test/kotlin/org/openbroker/TestTools.kt
+++ b/src/test/kotlin/org/openbroker/TestTools.kt
@@ -1,0 +1,2 @@
+package org.openbroker
+

--- a/src/test/kotlin/org/openbroker/TestTools.kt
+++ b/src/test/kotlin/org/openbroker/TestTools.kt
@@ -1,2 +1,18 @@
 package org.openbroker
 
+import org.openbroker.cloudevents.CloudEvent
+import org.openbroker.common.OpenBrokerEvent
+import org.openbroker.common.serialize.parseJsonCloudEvent
+import java.io.File
+
+private const val JSON_PATH = "src/test/resources/examples"
+
+internal fun loadJson(file: String): String {
+    val fileWithExtension: String = if(file.endsWith(".json")) file else "$file.json"
+    val completeFile = File("$JSON_PATH/$fileWithExtension")
+    require(completeFile.exists()) { "File cannot be found: $completeFile" }
+    return completeFile.readText()
+}
+
+internal inline fun <reified T: OpenBrokerEvent> parseJsonFromFile(file: String): CloudEvent<T> =
+    parseJsonCloudEvent(loadJson(file))

--- a/src/test/kotlin/org/openbroker/no/mortgage/DeserializationTest.kt
+++ b/src/test/kotlin/org/openbroker/no/mortgage/DeserializationTest.kt
@@ -1,0 +1,20 @@
+package org.openbroker.no.mortgage
+
+import org.junit.jupiter.api.Test
+import org.openbroker.no.mortgage.events.ApplicationCreated
+import org.openbroker.parseJsonFromFile
+
+class DeserializationTest {
+
+    /**
+     * This test will parse a JSON example file for an ApplicationCreated
+     * event where only the required values are present. The purpose of this
+     * test is to check that this library requires the same value as the
+     * specification does. If a required value is missing, an exception is
+     * thrown, and this test will fail.
+     */
+    @Test
+    fun parseApplicationCreatedWithOnlyRequiredValues() {
+        parseJsonFromFile<ApplicationCreated>("no/mortgage/MortgageApplicationCreated_Required")
+    }
+}

--- a/src/test/kotlin/org/openbroker/no/mortgage/EventTypeFactoryTest.kt
+++ b/src/test/kotlin/org/openbroker/no/mortgage/EventTypeFactoryTest.kt
@@ -1,0 +1,4 @@
+package org.openbroker.no.mortgage
+
+class EventTypeFactoryTest {
+}

--- a/src/test/kotlin/org/openbroker/no/mortgage/EventTypeFactoryTest.kt
+++ b/src/test/kotlin/org/openbroker/no/mortgage/EventTypeFactoryTest.kt
@@ -15,7 +15,7 @@ import org.openbroker.parseJsonFromFile
 
 class EventTypeFactoryTest {
     private val applicationCreated: CloudEvent<ApplicationCreated> = parseJsonFromFile("no/mortgage/MortgageApplicationCreated")
-    private val offering: CloudEvent<Offering> = parseJsonFromFile("no/mortgage/MortgageApplicationOffering")
+    private val offering: CloudEvent<Offering> = parseJsonFromFile("no/mortgage/MortgageOffering")
     private val applicationRejection: CloudEvent<ApplicationRejection> = parseJsonFromFile("no/mortgage/MortgageApplicationRejection")
     private val disbursed: CloudEvent<Disbursed> = parseJsonFromFile("no/mortgage/MortgageDisbursed")
     private val message: CloudEvent<Message> = parseJsonFromFile("no/mortgage/MortgageMessage")

--- a/src/test/kotlin/org/openbroker/no/mortgage/EventTypeFactoryTest.kt
+++ b/src/test/kotlin/org/openbroker/no/mortgage/EventTypeFactoryTest.kt
@@ -1,4 +1,54 @@
 package org.openbroker.no.mortgage
 
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.openbroker.cloudevents.CloudEvent
+import org.openbroker.no.mortgage.events.ApplicationCreated
+import org.openbroker.no.mortgage.events.ApplicationRejection
+import org.openbroker.no.mortgage.events.Disbursed
+import org.openbroker.no.mortgage.events.Message
+import org.openbroker.no.mortgage.events.MortgageEvent
+import org.openbroker.no.mortgage.events.OfferAccepted
+import org.openbroker.no.mortgage.events.OfferRejected
+import org.openbroker.no.mortgage.events.Offering
+import org.openbroker.parseJsonFromFile
+
 class EventTypeFactoryTest {
+    private val applicationCreated: CloudEvent<ApplicationCreated> = parseJsonFromFile("no/mortgage/MortgageApplicationCreated")
+    private val offering: CloudEvent<Offering> = parseJsonFromFile("no/mortgage/MortgageApplicationOffering")
+    private val applicationRejection: CloudEvent<ApplicationRejection> = parseJsonFromFile("no/mortgage/MortgageApplicationRejection")
+    private val disbursed: CloudEvent<Disbursed> = parseJsonFromFile("no/mortgage/MortgageDisbursed")
+    private val message: CloudEvent<Message> = parseJsonFromFile("no/mortgage/MortgageMessage")
+    private val offerAccepted: CloudEvent<OfferAccepted> = parseJsonFromFile("no/mortgage/MortgageOfferAccepted")
+    private val offerRejected: CloudEvent<OfferRejected> = parseJsonFromFile("no/mortgage/MortgageOfferRejected")
+
+    /**
+     * This test makes sure that
+     * 1. Parsing JSON examples files (or JSON String representation in general)
+     * to the JVM class counterpart works as intended
+     * 2. That the [Comparator] in [MortgageNorway] works as intended
+     */
+    @Test
+    fun testCorrectSortingByComparator() {
+        val events: List<MortgageEvent> = sequenceOf(
+            applicationCreated,
+            offering,
+            applicationRejection,
+            disbursed,
+            message,
+            offerAccepted,
+            offerRejected
+        )
+            .map { it.data!! }
+            .toList()
+            .sortedWith(MortgageNorway)
+
+        assertEquals(applicationCreated.data!!, events[0])
+        assertEquals(offering.data!!, events[1])
+        assertEquals(applicationRejection.data!!, events[2])
+        assertEquals(offerRejected.data!!, events[3])
+        assertEquals(offerAccepted.data!!, events[4])
+        assertEquals(disbursed.data!!, events[5])
+        assertEquals(message.data!!, events[6])
+    }
 }

--- a/src/test/resources/examples/no/mortgage/MortgageApplicationCreated.json
+++ b/src/test/resources/examples/no/mortgage/MortgageApplicationCreated.json
@@ -1,0 +1,128 @@
+{
+    "cloudEventsVersion": "0.1",
+    "eventType": "org.open-broker.v0.no.MortgageApplicationCreated",
+    "eventTypeVersion": "v0",
+    "source": "/mycontext",
+    "eventID": "C234-12D4-1234",
+    "eventTime": "2019-04-05T17:31:00Z",
+    "extensions": {
+        "comExampleExtension": "value"
+    },
+    "contentType": "application/json",
+    "data": {
+        "brokerReference": {
+            "issuer": "io.klira",
+            "id": "hc8awe-ja8oJOJ8-ha0Xa2P"
+        },
+        "dataProtectionContext": "FICTIONAL",
+        "application": {
+            "applicant": {
+                "ssn": "12345678901",
+                "phone": "+47123456789",
+                "secondaryPhone": [
+                    "+47456789123",
+                    "+47678912340"
+                ],
+                "emailAddress": "espen@protonmail.com",
+                "dependentChildren": 3,
+                "employmentStatus": "PUBLIC_SECTOR",
+                "employmentStatusSinceMonth": 3,
+                "employmentStatusSinceYear": 2016,
+                "employerName": "Company Inc",
+                "employerPhone": "+474526327908",
+                "childSupportReceivedMonthly": 900,
+                "rentReceivedMonthly": 2000,
+                "otherIncomeReceivedMonthly": 400,
+                "childSupportPaidMonthly": 0,
+                "paymentRemark": false,
+                "housingCostPerMonth": 800,
+                "housingType": "OWN_APARTMENT",
+                "maritalStatus": "MARRIED",
+                "monthlyGrossIncome": 23000,
+                "monthlyNetIncome": 20000,
+                "norwegianCitizen": true,
+                "education": "UNIVERSITY_LONG",
+                "tentativeAddress": {
+                    "firstName": "Espen",
+                    "lastName": "Knutsen",
+                    "address": "Lang vei 42",
+                    "city": "Narvik",
+                    "postalCode": "1234",
+                    "careOf": "Hans"
+                }
+            },
+            "coApplicant": {
+                "ssn": "12345678902",
+                "emailAddress": "erlend@pm.me",
+                "dependentChildren": 2,
+                "employmentStatus": "DOMESTIC",
+                "employmentStatusSinceMonth": 5,
+                "employmentStatusSinceYear": 2012,
+                "housingCostPerMonth": 1200,
+                "housingType": "RENTED",
+                "maritalStatus": "MARRIED",
+                "monthlyGrossIncome": 43000,
+                "monthlyNetIncome": 24000,
+                "norwegianCitizen": true,
+                "paymentRemark": false,
+                "education": "SECONDARY_SCHOOL",
+                "tentativeAddress": {
+                    "firstName": "Erlend",
+                    "lastName": "Loe",
+                    "address": "Svingete vei 1",
+                    "city": "Oslo",
+                    "postalCode": "0232"
+                }
+            },
+            "existingLoans": [
+                {
+                    "loanAmount": 45000,
+                    "monthlyPayment": 1400,
+                    "refinanceAmount": 45000,
+                    "existingLoanType": "CREDIT_CARD",
+                    "responsibility": "MAIN_APPLICANT",
+                    "lender": "XYZ Bank",
+                    "defaulted": false
+                },
+                {
+                    "loanAmount": 122000,
+                    "monthlyPayment": 1700,
+                    "refinanceAmount": 80000,
+                    "existingLoanType": "CAR_LOAN",
+                    "responsibility": "SHARED",
+                    "lender": "ABC Bank",
+                    "defaulted": false
+                },
+                {
+                    "loanAmount": 890000,
+                    "monthlyPayment": 3200,
+                    "refinanceAmount": 0,
+                    "existingLoanType": "MORTGAGE",
+                    "responsibility": "CO_APPLICANT",
+                    "lender": "ABC Bank",
+                    "defaulted": false
+                }
+            ],
+            "loanAmount": 2500000,
+            "loanPurpose": "REFINANCE_CONSUMER_LOANS",
+            "termYears": 30,
+            "refinanceAmount": 2500000,
+            "refinancingProperty": {
+                "interestRate": "0.067",
+                "assessedValue": "3300000",
+                "propertyAddress": {
+                    "streetAddress": "Nobels gate 16",
+                    "city": "Oslo",
+                    "postalCode": "0244"
+                },
+                "propertyType": "APARTMENT_SELF_OWNED",
+                "squareMeters": 196,
+                "existingMortgage": 2500000,
+                "monthlyCost": 6700,
+                "condominiumCompoundDebt": null,
+                "defaulted": false
+            },
+            "comment": "Co applicant will retire within six months"
+        }
+    }
+}

--- a/src/test/resources/examples/no/mortgage/MortgageApplicationCreated_Required.json
+++ b/src/test/resources/examples/no/mortgage/MortgageApplicationCreated_Required.json
@@ -1,0 +1,54 @@
+{
+    "cloudEventsVersion": "0.1",
+    "eventType": "org.open-broker.v0.no.MortgageApplicationCreated",
+    "eventTypeVersion": "v0",
+    "source": "/mycontext",
+    "eventID": "C234-12D4-1234",
+    "eventTime": "2019-04-05T17:31:00Z",
+    "extensions": {
+        "comExampleExtension": "value"
+    },
+    "contentType": "application/json",
+    "data": {
+        "brokerReference": {
+            "issuer": "io.klira",
+            "id": "hc8awe-ja8oJOJ8-ha0Xa2P"
+        },
+        "dataProtectionContext": "FICTIONAL",
+        "application": {
+            "applicant": {
+                "ssn": "12345678901",
+                "emailAddress": "espen@protonmail.com",
+                "dependentChildren": 3,
+                "employmentStatus": "PUBLIC_SECTOR",
+                "employmentStatusSinceMonth": 3,
+                "employmentStatusSinceYear": 2016,
+                "paymentRemark": false,
+                "housingCostPerMonth": 800,
+                "housingType": "OWN_APARTMENT",
+                "maritalStatus": "MARRIED",
+                "monthlyGrossIncome": 23000,
+                "monthlyNetIncome": 20000,
+                "norwegianCitizen": true
+            },
+            "loanAmount": 2500000,
+            "loanPurpose": "REFINANCE_CONSUMER_LOANS",
+            "termYears": 30,
+            "refinanceAmount": 2500000,
+            "refinancingProperty": {
+                "interestRate": "0.067",
+                "assessedValue": "3300000",
+                "propertyAddress": {
+                    "streetAddress": "Nobels gate 16",
+                    "city": "Oslo",
+                    "postalCode": "0244"
+                },
+                "propertyType": "APARTMENT_SELF_OWNED",
+                "squareMeters": 196,
+                "existingMortgage": 2500000,
+                "monthlyCost": 6700,
+                "defaulted": false
+            }
+        }
+    }
+}

--- a/src/test/resources/examples/no/mortgage/MortgageApplicationRejection.json
+++ b/src/test/resources/examples/no/mortgage/MortgageApplicationRejection.json
@@ -1,0 +1,19 @@
+{
+  "cloudEventsVersion" : "0.1",
+  "eventType" : "org.open-broker.v0.no.MortgageApplicationRejection",
+  "eventTypeVersion" : "v0",
+  "source" : "/mycontext",
+  "eventID" : "C234-1234-1234",
+  "eventTime" : "2018-04-05T17:31:00Z",
+  "extensions" : {
+    "comExampleExtension" : "value"
+  },
+  "contentType" : "application/json",
+  "data": {
+    "brokerReference": {
+      "id": "14-0e2375ac997e17a54c1106a7e120fcf3b18a59de923bf4b5d14a61aea93a2a6a",
+      "issuer": "io.klira"
+    },
+    "rejectReason": "No e-mail was provided in application"
+  }
+}

--- a/src/test/resources/examples/no/mortgage/MortgageDisbursed.json
+++ b/src/test/resources/examples/no/mortgage/MortgageDisbursed.json
@@ -1,0 +1,17 @@
+{
+    "cloudEventsVersion": "0.1",
+    "eventType": "org.open-broker.v0.no.MortgageDisbursed",
+    "source": "/mycontext",
+    "eventID": "r6RDiSnc0w5zh9pilH3S8WrcXwkmXTGc",
+    "eventTime": "2019-04-19T23:11:14Z",
+    "contentType": "application/json",
+        "data": {
+        "brokerReference": {
+            "issuer": "io.klira",
+            "id": "au092.9a9s8dA.0OxZkaak"
+        },
+        "amountDisbursed": 670000,
+        "amountBrokered": 450000,
+        "date": "2019-04-22"
+    }
+}

--- a/src/test/resources/examples/no/mortgage/MortgageMessage.json
+++ b/src/test/resources/examples/no/mortgage/MortgageMessage.json
@@ -1,0 +1,20 @@
+{
+  "cloudEventsVersion" : "0.1",
+  "eventType" : "org.open-broker.v0.no.MortgageMessage",
+  "eventTypeVersion" : "v0",
+  "source" : "/mycontext",
+  "eventID" : "C234-1234-1234",
+  "eventTime" : "2018-04-05T17:31:00Z",
+  "extensions" : {
+    "comExampleExtension" : "value"
+  },
+  "contentType" : "application/json",
+  "data": {
+    "brokerReference": {
+      "id": "14-0e2375ac997e17a54c1106a7e120fcf3b18a59de923bf4b5d14a61aea93a2a6a",
+      "issuer": "io.klira"
+    },
+    "message": "Application will be processed manually",
+    "requiresAction": false
+  }
+}

--- a/src/test/resources/examples/no/mortgage/MortgageOfferAccepted.json
+++ b/src/test/resources/examples/no/mortgage/MortgageOfferAccepted.json
@@ -1,0 +1,20 @@
+{
+  "cloudEventsVersion": "0.1",
+  "eventType": "org.open-broker.v0.no.MortgageOfferAccepted",
+  "eventTypeVersion": "v0",
+  "source": "/mycontext",
+  "eventID": "C234-1234-1234",
+  "eventTime": "2018-04-05T17:31:00Z",
+  "extensions": {
+    "comExampleExtension": "value"
+  },
+  "contentType": "application/json",
+  "data": {
+    "brokerReference": {
+      "id": "14-0e2375ac997e17a54c1106a7e120fcf3b18a59de923bf4b5d14a61aea93a2a6a",
+      "issuer": "io.klira"
+    },
+    "bankAccount": "12345678901",
+    "requestedCredit": 25000
+  }
+}

--- a/src/test/resources/examples/no/mortgage/MortgageOfferRejected.json
+++ b/src/test/resources/examples/no/mortgage/MortgageOfferRejected.json
@@ -1,0 +1,18 @@
+{
+  "cloudEventsVersion" : "0.1",
+  "eventType" : "org.open-broker.v0.no.MortgageOfferRejected",
+  "eventTypeVersion" : "v0",
+  "source" : "/mycontext",
+  "eventID" : "C234-1234-1234",
+  "eventTime" : "2018-04-05T17:31:00Z",
+  "extensions" : {
+    "comExampleExtension" : "value"
+  },
+  "contentType" : "application/json",
+  "data": {
+    "brokerReference": {
+      "id": "14-0e2375ac997e17a54c1106a7e120fcf3b18a59de923bf4b5d14a61aea93a2a6a",
+      "issuer": "io.klira"
+    }
+  }
+}

--- a/src/test/resources/examples/no/mortgage/MortgageOffering.json
+++ b/src/test/resources/examples/no/mortgage/MortgageOffering.json
@@ -1,0 +1,30 @@
+{
+  "cloudEventsVersion": "0.1",
+  "eventType": "org.open-broker.v0.no.MortgageOffering",
+  "eventTypeVersion": "v0",
+  "source": "/mycontext",
+  "eventID": "C234-1234-1234",
+  "eventTime": "2018-04-05T17:31:00Z",
+  "extensions": {
+    "comExampleExtension": "value"
+  },
+  "contentType": "application/json",
+  "data": {
+    "brokerReference": {
+      "id": "14-0e2375ac997e17a54c1106a7e120fcf3b18a59de923bf4b5d14a61aea93a2a6a",
+      "issuer": "io.klira"
+    },
+    "offer": {
+      "arrangementFee": 0,
+      "amortizationType": "ANNUITY",
+      "effectiveInterestRate": "0.0345",
+      "nominalInterestRate": "0.0345",
+      "invoiceFee": 233,
+      "monthlyCost": 123,
+      "mustRefinance": 234,
+      "offeredCredit": 123456,
+      "termFee": 1234,
+      "termYears": 25
+    }
+  }
+}


### PR DESCRIPTION
The only major difference from how this is implemented to compare to Mortgage Sweden/PrivateConsumerLoan Norway is that the cases is based actual JSON files (taken from the examples in the specification). This will make it is easier in the future if we change the specification (and we must change examples for it to pass in CircleCI) since we can just copy past the examples from there.