### PR TITLE
Removes matching Application [extension key] with [issuer regex]

### DIFF
--- a/src/main/kotlin/org/openbroker/no/mortgage/model/Application.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/model/Application.kt
@@ -59,10 +59,5 @@ data class Application @JvmOverloads constructor(
         require(refinanceAmount <= loanAmount) {
             "refinanceAmount ($refinanceAmount) may not be greater than loanAmount ($loanAmount)."
         }
-        extensions?.keys?.forEach { key ->
-            require(key.matches(issuerRegex)) {
-                "Key for extension is not a valid format: '$key'"
-            }
-        }
     }
 }

--- a/src/main/kotlin/org/openbroker/no/privateunsecuredloan/model/Application.kt
+++ b/src/main/kotlin/org/openbroker/no/privateunsecuredloan/model/Application.kt
@@ -51,10 +51,5 @@ data class Application @JvmOverloads constructor(
         require(refinanceAmount <= loanAmount) {
             "refinanceAmount ($refinanceAmount) may not be greater than loanAmount ($loanAmount)."
         }
-        extensions?.keys?.forEach { key ->
-            require(key.matches(issuerRegex)) {
-                "Key for extension is not a valid format: '$key'"
-            }
-        }
     }
 }

--- a/src/main/kotlin/org/openbroker/se/privateunsecuredloan/model/Application.kt
+++ b/src/main/kotlin/org/openbroker/se/privateunsecuredloan/model/Application.kt
@@ -52,11 +52,5 @@ data class Application @JvmOverloads constructor(
         require(refinanceAmount <= loanAmount) {
             "refinanceAmount ($refinanceAmount) may not be greater than loanAmount ($loanAmount)."
         }
-
-        extensions?.keys?.forEach { key ->
-            require(key.matches(issuerRegex)) {
-                "Key for extension is not a valid format: '$key'"
-            }
-        }
     }
 }


### PR DESCRIPTION
From what I can tell there is no need to require the [extension key] in an Application object to match with the issuer regex.

So this matching has been removed from the init block for all Application classes where it occured.

Do you agree?