### PR TITLE
Add offerId to all domains

### DIFF
--- a/src/main/kotlin/org/openbroker/no/mortgage/events/Disbursed.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/events/Disbursed.kt
@@ -8,6 +8,7 @@ import org.openbroker.common.requireMin
  */
 data class Disbursed(
     override val brokerReference: Reference,
+    val offerId: Reference? = null,
 
     /**
      * The total amount disbursed to the customer of the loan being brokered

--- a/src/main/kotlin/org/openbroker/no/mortgage/events/OfferAccepted.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/events/OfferAccepted.kt
@@ -5,6 +5,7 @@ import org.openbroker.common.requireMin
 
 data class OfferAccepted @JvmOverloads constructor(
     override val brokerReference: Reference,
+    val offerId: Reference? = null,
     val bankAccount: String? = null,
     val requestedCredit: Int? = null
 ): MortgageEvent

--- a/src/main/kotlin/org/openbroker/no/mortgage/events/OfferRejected.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/events/OfferRejected.kt
@@ -6,4 +6,7 @@ import org.openbroker.common.model.Reference
  * An event that may be sent by the broker to indicate that
  * the offer has been rejected
  */
-data class OfferRejected(override val brokerReference: Reference): MortgageEvent
+data class OfferRejected(
+    override val brokerReference: Reference,
+    val offerId: Reference? = null
+): MortgageEvent

--- a/src/main/kotlin/org/openbroker/no/mortgage/events/Offering.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/events/Offering.kt
@@ -8,5 +8,6 @@ import org.openbroker.no.mortgage.model.Offer
  */
 data class Offering constructor(
     override val brokerReference: Reference,
+    val offerId: Reference? = null,
     val offer: Offer
 ): MortgageEvent

--- a/src/main/kotlin/org/openbroker/no/mortgage/model/Applicant.kt
+++ b/src/main/kotlin/org/openbroker/no/mortgage/model/Applicant.kt
@@ -63,5 +63,4 @@ data class Applicant @JvmOverloads constructor(
             "Value for monthlyNetIncome cannot be greater than value for monthlyGrossIncome"
         }
     }
-
 }

--- a/src/main/kotlin/org/openbroker/no/privateunsecuredloan/events/Disbursed.kt
+++ b/src/main/kotlin/org/openbroker/no/privateunsecuredloan/events/Disbursed.kt
@@ -8,6 +8,7 @@ import org.openbroker.common.requireMin
  */
 data class Disbursed(
     override val brokerReference: Reference,
+    val offerId: Reference? = null,
 
     /**
      * The total amount disbursed to the customer of the loan being brokered

--- a/src/main/kotlin/org/openbroker/no/privateunsecuredloan/events/OfferAccepted.kt
+++ b/src/main/kotlin/org/openbroker/no/privateunsecuredloan/events/OfferAccepted.kt
@@ -5,6 +5,7 @@ import org.openbroker.common.requireMin
 
 data class OfferAccepted @JvmOverloads constructor(
     override val brokerReference: Reference,
+    val offerId: Reference? = null,
     val bankAccount: String? = null,
     val requestedCredit: Int? = null
 ): PrivateUnsecuredLoanEvent

--- a/src/main/kotlin/org/openbroker/no/privateunsecuredloan/events/OfferRejected.kt
+++ b/src/main/kotlin/org/openbroker/no/privateunsecuredloan/events/OfferRejected.kt
@@ -6,4 +6,7 @@ import org.openbroker.common.model.Reference
  * An event that may be sent by the broker to indicate that
  * the offer has been rejected
  */
-data class OfferRejected(override val brokerReference: Reference): PrivateUnsecuredLoanEvent
+data class OfferRejected(
+    override val brokerReference: Reference,
+    val offerId: Reference? = null
+): PrivateUnsecuredLoanEvent

--- a/src/main/kotlin/org/openbroker/no/privateunsecuredloan/events/Offering.kt
+++ b/src/main/kotlin/org/openbroker/no/privateunsecuredloan/events/Offering.kt
@@ -9,6 +9,7 @@ import org.openbroker.no.privateunsecuredloan.model.Offer
  */
 data class Offering @JvmOverloads constructor(
     override val brokerReference: Reference,
+    val offerId: Reference? = null,
     val offer: Offer,
     val loanInsuranceOffer: LoanInsuranceOffer? = null
 ): PrivateUnsecuredLoanEvent

--- a/src/main/kotlin/org/openbroker/se/mortgage/events/Disbursed.kt
+++ b/src/main/kotlin/org/openbroker/se/mortgage/events/Disbursed.kt
@@ -17,7 +17,13 @@ data class Disbursed(
      *  The date for which the loan was disbursed, formatted
      *  as a ISO-8601 date, in the extended format YYYY-MM-DD
      */
-    val date: String
+    val date: String,
+
+    /**
+     * An id for the offer that has been disbursed,
+     * if the offer has an identifier
+     */
+    val offerId: Reference? = null
 ): MortgageEvent
 {
     init {

--- a/src/main/kotlin/org/openbroker/se/mortgage/events/OfferAccepted.kt
+++ b/src/main/kotlin/org/openbroker/se/mortgage/events/OfferAccepted.kt
@@ -5,5 +5,6 @@ import org.openbroker.common.model.Reference
 
 data class OfferAccepted constructor(
     override val brokerReference: Reference,
+    val offerId: Reference? = null,
     val bankAccount: BankAccount? = null
 ): MortgageEvent

--- a/src/main/kotlin/org/openbroker/se/mortgage/events/OfferRejected.kt
+++ b/src/main/kotlin/org/openbroker/se/mortgage/events/OfferRejected.kt
@@ -6,4 +6,7 @@ import org.openbroker.common.model.Reference
  * An event that may be sent by the broker to indicate that
  * the offer has been rejected by the customer
  */
-data class OfferRejected(override val brokerReference: Reference): MortgageEvent
+data class OfferRejected(
+    override val brokerReference: Reference,
+    val offerId: Reference? = null
+): MortgageEvent

--- a/src/main/kotlin/org/openbroker/se/mortgage/events/Offering.kt
+++ b/src/main/kotlin/org/openbroker/se/mortgage/events/Offering.kt
@@ -8,5 +8,6 @@ import org.openbroker.common.model.Reference
  */
 data class Offering constructor(
     override val brokerReference: Reference,
+    val offerId: Reference? = null,
     val offer: Offer
 ): MortgageEvent

--- a/src/main/kotlin/org/openbroker/se/privateunsecuredloan/events/Disbursed.kt
+++ b/src/main/kotlin/org/openbroker/se/privateunsecuredloan/events/Disbursed.kt
@@ -8,6 +8,7 @@ import org.openbroker.common.requireMin
  */
 data class Disbursed(
     override val brokerReference: Reference,
+    val offerId: Reference? = null,
 
     /**
      * The total amount disbursed to the customer of the loan being brokered

--- a/src/main/kotlin/org/openbroker/se/privateunsecuredloan/events/OfferAccepted.kt
+++ b/src/main/kotlin/org/openbroker/se/privateunsecuredloan/events/OfferAccepted.kt
@@ -6,6 +6,7 @@ import org.openbroker.common.requireMin
 
 data class OfferAccepted @JvmOverloads constructor(
     override val brokerReference: Reference,
+    val offerId: Reference? = null,
     val bankAccount: BankAccount? = null,
     val requestedCredit: Int? = null
 ): PrivateUnsecuredLoanEvent

--- a/src/main/kotlin/org/openbroker/se/privateunsecuredloan/events/OfferRejected.kt
+++ b/src/main/kotlin/org/openbroker/se/privateunsecuredloan/events/OfferRejected.kt
@@ -6,4 +6,7 @@ import org.openbroker.common.model.Reference
  * An event that may be sent by the broker to indicate that
  * the offer has been rejected
  */
-data class OfferRejected(override val brokerReference: Reference): PrivateUnsecuredLoanEvent
+data class OfferRejected(
+    override val brokerReference: Reference,
+    val offerId: Reference? = null
+): PrivateUnsecuredLoanEvent

--- a/src/main/kotlin/org/openbroker/se/privateunsecuredloan/events/Offering.kt
+++ b/src/main/kotlin/org/openbroker/se/privateunsecuredloan/events/Offering.kt
@@ -9,6 +9,7 @@ import org.openbroker.common.model.Reference
  */
 data class Offering @JvmOverloads constructor(
     override val brokerReference: Reference,
+    val offerId: Reference? = null,
     val offer: Offer,
     val loanInsuranceOffer: LoanInsuranceOffer? = null
 ): PrivateUnsecuredLoanEvent

--- a/src/test/java/org/openbroker/no/OpenBrokerCreateTest.java
+++ b/src/test/java/org/openbroker/no/OpenBrokerCreateTest.java
@@ -13,7 +13,11 @@ public class OpenBrokerCreateTest {
     @Test
     public void testCreateOpenBrokerEvent() {
         CloudEvent<OfferAccepted> accept = OpenBrokerEventKt.create(
-            new OfferAccepted(new Reference("1", "io.klira"), "12345678901"),
+            new OfferAccepted(
+                new Reference("1", "io.klira"),
+                new Reference("123", "com.creditor"),
+                "12345678901"
+            ),
             OfferAccepted.class,
             "source"
         );

--- a/src/test/java/org/openbroker/se/OpenBrokerCreateTest.java
+++ b/src/test/java/org/openbroker/se/OpenBrokerCreateTest.java
@@ -14,7 +14,11 @@ public class OpenBrokerCreateTest {
     @Test
     public void testCreateOpenBrokerEvent() {
         CloudEvent<OfferAccepted> accept = OpenBrokerEventKt.create(
-            new OfferAccepted(new Reference("1", "io.klira"), new BankAccount("3300", "1234567890")),
+            new OfferAccepted(
+                new Reference("1", "io.klira"),
+                new Reference("2", "com.creditor"),
+                new BankAccount("3300", "1234567890")
+            ),
             OfferAccepted.class,
             "source"
         );

--- a/src/test/java/org/openbroker/se/privateunsecuredloan/TestObjectsJava.java
+++ b/src/test/java/org/openbroker/se/privateunsecuredloan/TestObjectsJava.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 
 class TestObjectsJava {
     private static Reference reference = new Reference("S1", "io.klira");
+    private static Reference offerId =  new Reference("1", "com.creditor");
     private static String source = "klira.io";
 
     static CloudEvent<ApplicationCreated> applicationCreated = OpenBrokerEventKt.create(
@@ -75,6 +76,7 @@ class TestObjectsJava {
     static CloudEvent<Offering> offering = OpenBrokerEventKt.create(
         new Offering(
             reference,
+            offerId,
             new Offer(
             "14.5",
             "12.1",
@@ -98,7 +100,8 @@ class TestObjectsJava {
 
     static CloudEvent<OfferRejected> offerRejected = OpenBrokerEventKt.create(
         new OfferRejected(
-            reference
+            reference,
+            offerId
         ),
         OfferRejected.class,
         source
@@ -106,7 +109,8 @@ class TestObjectsJava {
 
     static CloudEvent<OfferAccepted> offerAccepted = OpenBrokerEventKt.create(
         new OfferAccepted(
-            reference
+            reference,
+            offerId
         ),
         OfferAccepted.class,
         source
@@ -124,6 +128,7 @@ class TestObjectsJava {
     static CloudEvent<Disbursed> disbursed = OpenBrokerEventKt.create(
         new Disbursed(
             reference,
+            offerId,
             240_000,
             240_000
         ),

--- a/src/test/resources/examples/no/mortgage/MortgageDisbursed.json
+++ b/src/test/resources/examples/no/mortgage/MortgageDisbursed.json
@@ -10,6 +10,10 @@
             "issuer": "io.klira",
             "id": "au092.9a9s8dA.0OxZkaak"
         },
+        "offerId": {
+            "issuer": "com.creditor",
+            "id": "810925.xSdh78ao8wiogf6"
+        },
         "amountDisbursed": 670000,
         "amountBrokered": 450000,
         "date": "2019-04-22"

--- a/src/test/resources/examples/no/mortgage/MortgageOfferAccepted.json
+++ b/src/test/resources/examples/no/mortgage/MortgageOfferAccepted.json
@@ -14,6 +14,10 @@
       "id": "14-0e2375ac997e17a54c1106a7e120fcf3b18a59de923bf4b5d14a61aea93a2a6a",
       "issuer": "io.klira"
     },
+    "offerId": {
+      "issuer": "com.creditor",
+      "id": "810925.xSdh78ao8wiogf6"
+    },
     "bankAccount": "12345678901",
     "requestedCredit": 25000
   }

--- a/src/test/resources/examples/no/mortgage/MortgageOfferRejected.json
+++ b/src/test/resources/examples/no/mortgage/MortgageOfferRejected.json
@@ -13,6 +13,10 @@
     "brokerReference": {
       "id": "14-0e2375ac997e17a54c1106a7e120fcf3b18a59de923bf4b5d14a61aea93a2a6a",
       "issuer": "io.klira"
+    },
+    "offerId": {
+      "issuer": "com.creditor",
+      "id": "810925.xSdh78ao8wiogf6"
     }
   }
 }

--- a/src/test/resources/examples/no/mortgage/MortgageOffering.json
+++ b/src/test/resources/examples/no/mortgage/MortgageOffering.json
@@ -14,6 +14,10 @@
       "id": "14-0e2375ac997e17a54c1106a7e120fcf3b18a59de923bf4b5d14a61aea93a2a6a",
       "issuer": "io.klira"
     },
+    "offerId": {
+      "issuer": "com.creditor",
+      "id": "810925.xSdh78ao8wiogf6"
+    },
     "offer": {
       "arrangementFee": 0,
       "amortizationType": "ANNUITY",


### PR DESCRIPTION
Add offerId to PrivateUnsecuredLoan (SE), PrivateUnsecuredLoan (NO), Mortgage (SE) and Mortgage (NO) for events "Offering", "OfferAccepted", "OfferRejected" and "Disbursed"