### PR TITLE
 Update version of Jackson dependencies to 2.10.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,13 +33,13 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     // Cloud Events
-    compile 'com.github.open-broker:cloud-events-jvm:b8b9c6fef37'
-    compile 'com.github.open-broker:cloud-events-jvm:b8b9c6fef37:sources'
+    compile 'com.github.open-broker:cloud-events-jvm:f5a3f2e428'
+    compile 'com.github.open-broker:cloud-events-jvm:f5a3f2e428:sources'
 
     // Jackson
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version:'2.9.8'
-    implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version:'2.9.8'
-    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version:'2.9.8'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version:'2.10.1'
+    implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version:'2.10.1'
+    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version:'2.10.1'
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.3.1")
     testRuntime("org.junit.jupiter:junit-jupiter-engine:5.3.1")


### PR DESCRIPTION
 Update all dependencies that relies on jackson-databind either
 as a direct dependency or as a transitive depedency. Purpose of update
 is to not use older versions of jackson-databind, which
 is susceptible to several security vulnerabilities. Relevant CVEs are:
  - CVE-2019-14540
  - CVE-2019-16335
  - CVE-2019-14379
  - CVE-2019-17531