### PR TITLE
Add property 'refinanceAmount' to ExistingLoan in SE

### DIFF
--- a/src/main/kotlin/org/openbroker/se/privateunsecuredloan/model/ExistingLoan.kt
+++ b/src/main/kotlin/org/openbroker/se/privateunsecuredloan/model/ExistingLoan.kt
@@ -6,6 +6,7 @@ data class ExistingLoan(
     val loanAmount: Int,
     val monthlyPayment: Int,
     val shouldRefinance: Boolean,
+    val refinanceAmount: Int? = null,
     val existingLoanType: ExistingLoanType,
     val responsibility: Responsibility
 ) {

--- a/src/test/kotlin/org/openbroker/se/privateunsecuredloan/TestObjectsJson.kt
+++ b/src/test/kotlin/org/openbroker/se/privateunsecuredloan/TestObjectsJson.kt
@@ -114,7 +114,7 @@ object TestObjectsJson {
 					"loanAmount": 4000,
 					"monthlyPayment": 22,
 					"shouldRefinance": true,
-                    "refinanceAmount": 4000,
+					"refinanceAmount": 4000,
 					"existingLoanType": "CAR_LOAN",
 					"responsibility": "SHARED"
 				},
@@ -122,7 +122,7 @@ object TestObjectsJson {
 					"loanAmount": 15000,
 					"monthlyPayment": 56,
 					"shouldRefinance": false,
-                    "refinanceAmount": 0,
+					"refinanceAmount": 0,
 					"existingLoanType": "STUDENT_LOAN",
 					"responsibility": "MAIN_APPLICANT"
 				}
@@ -168,7 +168,7 @@ object TestObjectsJson {
 					"loanAmount": 4000,
 					"monthlyPayment": 22,
 					"shouldRefinance": true,
-                    "refinanceAmount": 4000,
+					"refinanceAmount": 4000,
 					"existingLoanType": "CAR_LOAN",
 					"responsibility": "SHARED"
 				},
@@ -176,7 +176,7 @@ object TestObjectsJson {
 					"loanAmount": 15000,
 					"monthlyPayment": 56,
 					"shouldRefinance": false,
-                    "refinanceAmount": 0,
+					"refinanceAmount": 0,
 					"existingLoanType": "STUDENT_LOAN",
 					"responsibility": "MAIN_APPLICANT"
 				}
@@ -262,7 +262,7 @@ object TestObjectsJson {
 					"loanAmount": 4000,
 					"monthlyPayment": 22,
 					"shouldRefinance": true,
-                    "refinanceAmount": 4000,
+					"refinanceAmount": 4000,
 					"existingLoanType": "CAR_LOAN",
 					"responsibility": "SHARED"
 				},
@@ -270,7 +270,7 @@ object TestObjectsJson {
 					"loanAmount": 15000,
 					"monthlyPayment": 56,
 					"shouldRefinance": false,
-                    "refinanceAmount": 0,
+					"refinanceAmount": 0,
 					"existingLoanType": "STUDENT_LOAN",
 					"responsibility": "MAIN_APPLICANT"
 				}

--- a/src/test/kotlin/org/openbroker/se/privateunsecuredloan/TestObjectsJson.kt
+++ b/src/test/kotlin/org/openbroker/se/privateunsecuredloan/TestObjectsJson.kt
@@ -114,6 +114,7 @@ object TestObjectsJson {
 					"loanAmount": 4000,
 					"monthlyPayment": 22,
 					"shouldRefinance": true,
+                    "refinanceAmount": 4000,
 					"existingLoanType": "CAR_LOAN",
 					"responsibility": "SHARED"
 				},
@@ -121,6 +122,7 @@ object TestObjectsJson {
 					"loanAmount": 15000,
 					"monthlyPayment": 56,
 					"shouldRefinance": false,
+                    "refinanceAmount": 0,
 					"existingLoanType": "STUDENT_LOAN",
 					"responsibility": "MAIN_APPLICANT"
 				}
@@ -166,6 +168,7 @@ object TestObjectsJson {
 					"loanAmount": 4000,
 					"monthlyPayment": 22,
 					"shouldRefinance": true,
+                    "refinanceAmount": 4000,
 					"existingLoanType": "CAR_LOAN",
 					"responsibility": "SHARED"
 				},
@@ -173,6 +176,7 @@ object TestObjectsJson {
 					"loanAmount": 15000,
 					"monthlyPayment": 56,
 					"shouldRefinance": false,
+                    "refinanceAmount": 0,
 					"existingLoanType": "STUDENT_LOAN",
 					"responsibility": "MAIN_APPLICANT"
 				}
@@ -258,6 +262,7 @@ object TestObjectsJson {
 					"loanAmount": 4000,
 					"monthlyPayment": 22,
 					"shouldRefinance": true,
+                    "refinanceAmount": 4000,
 					"existingLoanType": "CAR_LOAN",
 					"responsibility": "SHARED"
 				},
@@ -265,6 +270,7 @@ object TestObjectsJson {
 					"loanAmount": 15000,
 					"monthlyPayment": 56,
 					"shouldRefinance": false,
+                    "refinanceAmount": 0,
 					"existingLoanType": "STUDENT_LOAN",
 					"responsibility": "MAIN_APPLICANT"
 				}

--- a/src/test/kotlin/org/openbroker/se/serialize/SerializationTest.kt
+++ b/src/test/kotlin/org/openbroker/se/serialize/SerializationTest.kt
@@ -62,8 +62,8 @@ class SerializationTest {
         val app = Application(
             applicant = applicant,
             existingLoans = listOf(
-                ExistingLoan(4000, 22, true, ExistingLoanType.CAR_LOAN, Responsibility.SHARED),
-                ExistingLoan(15_000, 56, false, ExistingLoanType.STUDENT_LOAN, Responsibility.MAIN_APPLICANT)
+                ExistingLoan(4000, 22, true, 4000, ExistingLoanType.CAR_LOAN, Responsibility.SHARED),
+                ExistingLoan(15_000, 56, false, 0, ExistingLoanType.STUDENT_LOAN, Responsibility.MAIN_APPLICANT)
             ),
             loanAmount = 20_000,
             termMonths = 24,


### PR DESCRIPTION
We got a requirement to add a property 'refinanceAmount' to existing loans in PrivateUnsecuredLoanApplicationCreated event for SE. Implementation is according to open-broker-specification (PR [106](https://github.com/open-broker/specification/pull/106)).