### PR TITLE
Add 'ssn' and 'ssnCoapplicant' to OfferAccepted

### DIFF
--- a/src/main/kotlin/org/openbroker/no/privateunsecuredloan/events/OfferAccepted.kt
+++ b/src/main/kotlin/org/openbroker/no/privateunsecuredloan/events/OfferAccepted.kt
@@ -1,6 +1,7 @@
 package org.openbroker.no.privateunsecuredloan.events
 
 import org.openbroker.common.model.Reference
+import org.openbroker.common.obfuscateDigits
 import org.openbroker.common.requireMin
 
 data class OfferAccepted @JvmOverloads constructor(
@@ -8,11 +9,25 @@ data class OfferAccepted @JvmOverloads constructor(
     val offerId: Reference? = null,
     val bankAccount: String? = null,
     val requestedCredit: Int? = null,
+    val ssn: String? = null,
+    val ssnCoapplicant: String? = null,
     val emailAddress: String? = null,
     val emailAddressCoapplicant: String? = null
-): PrivateUnsecuredLoanEvent
-{
+) : PrivateUnsecuredLoanEvent {
     init {
         requestedCredit.requireMin(1, "requestedCredit")
+
+        val ssnRegex = Regex("^[0-9]{11}$")
+        ssn?.let {
+            require(it.matches(ssnRegex)) {
+                "Invalid applicant's SSN: '${obfuscateDigits(it)}'"
+            }
+        }
+        ssnCoapplicant?.let {
+            require(it.matches(ssnRegex)) {
+                "Invalid co-applicant's SSN: '${obfuscateDigits(it)}'"
+            }
+        }
+
     }
 }

--- a/src/main/kotlin/org/openbroker/se/privateunsecuredloan/events/OfferAccepted.kt
+++ b/src/main/kotlin/org/openbroker/se/privateunsecuredloan/events/OfferAccepted.kt
@@ -2,6 +2,7 @@ package org.openbroker.se.privateunsecuredloan.events
 
 import org.openbroker.se.model.BankAccount
 import org.openbroker.common.model.Reference
+import org.openbroker.common.obfuscateDigits
 import org.openbroker.common.requireMin
 
 data class OfferAccepted @JvmOverloads constructor(
@@ -9,11 +10,24 @@ data class OfferAccepted @JvmOverloads constructor(
     val offerId: Reference? = null,
     val bankAccount: BankAccount? = null,
     val requestedCredit: Int? = null,
+    val ssn: String? = null,
+    val ssnCoapplicant: String? = null,
     val emailAddress: String? = null,
     val emailAddressCoapplicant: String? = null
-): PrivateUnsecuredLoanEvent
-{
+) : PrivateUnsecuredLoanEvent {
     init {
         requestedCredit.requireMin(1, "requestedCredit")
+
+        val ssnRegex = Regex("^[0-9]{12}$")
+        ssn?.let {
+            require(it.matches(ssnRegex)) {
+                "Invalid applicant's SSN: '${obfuscateDigits(it)}'"
+            }
+        }
+        ssnCoapplicant?.let {
+            require(it.matches(ssnRegex)) {
+                "Invalid co-applicant's SSN: '${obfuscateDigits(it)}'"
+            }
+        }
     }
 }


### PR DESCRIPTION
Adding properties "ssn" and "ssnCoapplicant" to PrivateUnsecuredLoanOfferAccepted event for both SE and NO according to requirement to send ssn with accept