### PR TITLE
Use GitHub Packages, fix scope deprecations in dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "org.jetbrains.kotlin.jvm" version "1.3.30"
+    id 'maven-publish'
 }
 
 apply plugin: 'kotlin'
@@ -8,7 +9,7 @@ apply plugin: 'maven'
 apply plugin: 'idea'
 
 group = 'org.openbroker'
-version = '1.0-SNAPSHOT'
+version = '1.0.2'
 description = 'Library for Open Broker'
 
 defaultTasks 'test'
@@ -23,16 +24,22 @@ apply from: "jar.gradle"
 
 repositories {
     mavenCentral()
-    maven { url "https://jitpack.io" }
+    maven {
+        url = uri("https://maven.pkg.github.com/open-broker/cloud-events-jvm")
+        credentials {
+            username = System.getenv("GITHUB_PACKAGES_USERNAME")
+            password = System.getenv("GITHUB_PACKAGES_PASSWORD")
+        }
+    }
 }
 
 dependencies {
     // Kotlin
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    api "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     // Cloud Events
-    compile 'com.github.open-broker:cloud-events-jvm:16139e7ff'
-    compile 'com.github.open-broker:cloud-events-jvm:16139e7ff:sources'
+    api 'org.openbroker:cloud-events-jvm:1.0.2'
+    api 'org.openbroker:cloud-events-jvm:1.0.2:sources'
 
     // Jackson
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version:'2.10.1'
@@ -40,7 +47,7 @@ dependencies {
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version:'2.10.1'
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.3.1")
-    testRuntime("org.junit.jupiter:junit-jupiter-engine:5.3.1")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.3.1")
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
@@ -66,4 +73,23 @@ test {
 wrapper{
     description = 'Generates gradlew[.bat] scripts for faster execution'
     gradleVersion = '6.8'
+}
+
+publishing {
+    repositories {
+        maven {
+            url = uri("https://maven.pkg.github.com/open-broker/open-broker-jvm")
+            credentials {
+                username = System.getenv("GITHUB_PACKAGES_USERNAME")
+                password = System.getenv("GITHUB_PACKAGES_PASSWORD")
+            }
+        }
+    }
+    publications {
+        github(MavenPublication) {
+            from components.java
+            artifact sourcesJar
+            artifact javadocJar
+        }
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ repositories {
 
 dependencies {
     // Kotlin
-    api "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     // Cloud Events
     api 'org.openbroker:cloud-events-jvm:1.0.2'


### PR DESCRIPTION
Use GitHub Packages, fix scope deprecations in dependencies. 
Will need to add env vars to use GitHub Packages and build the thing.
```
GitHub Packages only supports authentication using a personal access token (classic).
```