### PR TITLE
Improve 'interest rate' validation (offers)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'maven'
 apply plugin: 'idea'
 
 group = 'org.openbroker'
-version = '1.0.3'
+version = '1.0.4'
 description = 'Library for Open Broker'
 
 defaultTasks 'test'

--- a/src/main/kotlin/org/openbroker/no/privateunsecuredloan/model/Offer.kt
+++ b/src/main/kotlin/org/openbroker/no/privateunsecuredloan/model/Offer.kt
@@ -21,7 +21,7 @@ data class Offer(
     val amortizationType: AmortizationType? = null
 ) {
     init {
-        val interestRateRegex = Regex("^[0-9]+(.[0-9]+)?$")
+        val interestRateRegex = Regex("^0\\.\\d[1-9](\\d+)?$")
         effectiveInterestRate?.requireMatchRegex(interestRateRegex, "effectiveInterestRate")
         nominalInterestRate?.requireMatchRegex(interestRateRegex, "nominalInterestRate")
         minOfferedCredit?.requireMin(1, "minOfferedCredit")

--- a/src/main/kotlin/org/openbroker/no/privateunsecuredloan/model/Offer.kt
+++ b/src/main/kotlin/org/openbroker/no/privateunsecuredloan/model/Offer.kt
@@ -21,7 +21,7 @@ data class Offer(
     val amortizationType: AmortizationType? = null
 ) {
     init {
-        val interestRateRegex = Regex("^0\\.\\d[1-9](\\d+)?$")
+        val interestRateRegex = Regex("^0\\.([1-9]\\d?|\\d[1-9])(\\d+)?\$")
         effectiveInterestRate?.requireMatchRegex(interestRateRegex, "effectiveInterestRate")
         nominalInterestRate?.requireMatchRegex(interestRateRegex, "nominalInterestRate")
         minOfferedCredit?.requireMin(1, "minOfferedCredit")

--- a/src/main/kotlin/org/openbroker/se/privateunsecuredloan/model/Offer.kt
+++ b/src/main/kotlin/org/openbroker/se/privateunsecuredloan/model/Offer.kt
@@ -28,7 +28,7 @@ data class Offer(
     val comment: String? = null
 ) {
     init {
-        val interestRateRegex = Regex("^[0-9]+(.[0-9]+)?$")
+        val interestRateRegex = Regex("^0\\.\\d[1-9](\\d+)?$")
         effectiveInterestRate.requireMatchRegex(interestRateRegex, "effectiveInterestRate")
         nominalInterestRate.requireMatchRegex(interestRateRegex, "nominalInterestRate")
 

--- a/src/main/kotlin/org/openbroker/se/privateunsecuredloan/model/Offer.kt
+++ b/src/main/kotlin/org/openbroker/se/privateunsecuredloan/model/Offer.kt
@@ -28,7 +28,7 @@ data class Offer(
     val comment: String? = null
 ) {
     init {
-        val interestRateRegex = Regex("^0\\.\\d[1-9](\\d+)?$")
+        val interestRateRegex = Regex("^0\\.([1-9]\\d?|\\d[1-9])(\\d+)?\$")
         effectiveInterestRate.requireMatchRegex(interestRateRegex, "effectiveInterestRate")
         nominalInterestRate.requireMatchRegex(interestRateRegex, "nominalInterestRate")
 


### PR DESCRIPTION
Improve 'interest rate' validation so that only the numbers `0.0100...-0.9999...` are allowed.