### PR TITLE
feat: add origin field to blanco SE/NO Message events

### DIFF
--- a/src/main/kotlin/org/openbroker/common/model/Origin.kt
+++ b/src/main/kotlin/org/openbroker/common/model/Origin.kt
@@ -1,0 +1,9 @@
+package org.openbroker.common.model
+
+enum class Origin {
+
+    BANK,
+    BANKING_ADVISOR,
+    BROKER,
+    INTEGRATION
+}

--- a/src/main/kotlin/org/openbroker/no/privateunsecuredloan/events/Message.kt
+++ b/src/main/kotlin/org/openbroker/no/privateunsecuredloan/events/Message.kt
@@ -1,5 +1,6 @@
 package org.openbroker.no.privateunsecuredloan.events
 
+import org.openbroker.common.model.Origin
 import org.openbroker.common.model.Reference
 
 /**
@@ -9,5 +10,6 @@ import org.openbroker.common.model.Reference
 data class Message constructor(
     override val brokerReference: Reference,
     val message: String,
-    val requiresAction: Boolean
+    val requiresAction: Boolean,
+    val origin: Origin
 ) : PrivateUnsecuredLoanEvent

--- a/src/main/kotlin/org/openbroker/se/privateunsecuredloan/events/Message.kt
+++ b/src/main/kotlin/org/openbroker/se/privateunsecuredloan/events/Message.kt
@@ -1,5 +1,6 @@
 package org.openbroker.se.privateunsecuredloan.events
 
+import org.openbroker.common.model.Origin
 import org.openbroker.common.model.Reference
 
 /**
@@ -9,5 +10,6 @@ import org.openbroker.common.model.Reference
 data class Message constructor(
     override val brokerReference: Reference,
     val message: String,
-    val requiresAction: Boolean
+    val requiresAction: Boolean,
+    val origin: Origin
 ) : PrivateUnsecuredLoanEvent


### PR DESCRIPTION
Introduce Origin enum (BANK, BANKING_ADVISOR, BROKER, INTEGRATION) in org.openbroker.common.model and add a required `origin` property to the SE and NO PrivateUnsecuredLoanMessage events so consumers can identify the source of messages.